### PR TITLE
Fixes CVE-2021-45105, 45046, and 44228

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ scalacOptions ++= Seq(
 )
 
 val akka = "2.6.15"
-val log4j = "2.14.1"
+val log4j = "2.17.0"
 val jackson = "2.11.4"
 
 /* dependencies */


### PR DESCRIPTION
Fixes CVE-2021-45105, CVE-2021-45046, and CVE-2021-44228 by bumping log4j from 2.14.1 to 2,17.0
Server and Docker images should also be updated.